### PR TITLE
feat: add data, fallbackLang & lang options as constructor arguments

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -343,25 +343,25 @@ describe('constructor options', () => {
         });
     });
 
-    describe('defaultLang', () => {
+    describe('fallbackLang', () => {
         it('should return translation from default language in case of language data absence', () => {
             i18n = new I18N({
                 lang: 'sr',
-                defaultLang: 'en',
+                fallbackLang: 'en',
                 data: {en: {notification: {title: 'New version'}}},
             });
             expect(i18n.i18n('notification', 'title')).toBe('New version');
         });
 
         it('should return fallback from default language in case of language data absence', () => {
-            i18n = new I18N({lang: 'sr', defaultLang: 'en', data: {en: {notification: {}}}});
+            i18n = new I18N({lang: 'sr', fallbackLang: 'en', data: {en: {notification: {}}}});
             expect(i18n.i18n('notification', 'title')).toBe('title');
         });
 
         it('should return translation from default language in case of empty keyset', () => {
             i18n = new I18N({
                 lang: 'sr',
-                defaultLang: 'en',
+                fallbackLang: 'en',
                 data: {
                     en: {notification: {title: 'New version'}},
                     sr: {notification: {}},
@@ -373,7 +373,7 @@ describe('constructor options', () => {
         it('should return translation from default language in case of missing key', () => {
             i18n = new I18N({
                 lang: 'sr',
-                defaultLang: 'en',
+                fallbackLang: 'en',
                 data: {
                     en: {notification: {title: 'New version'}},
                     sr: {notification: {hey: 'Zdravo!'}},
@@ -385,7 +385,7 @@ describe('constructor options', () => {
         it('should return fallback from default language in case of missing key', () => {
             i18n = new I18N({
                 lang: 'sr',
-                defaultLang: 'en',
+                fallbackLang: 'en',
                 data: {
                     en: {notification: {hey: 'Hello!'}},
                     sr: {notification: {hey: 'Zdravo!'}},

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -310,6 +310,11 @@ describe('i18n', () => {
 });
 
 describe('constructor options', () => {
+    it('should throw an error in case of languages absence', () => {
+        i18n = new I18N();
+        expect(() => i18n.i18n('notification', 'title')).toThrow();
+    });
+
     describe('lang', () => {
         it('should return translation [set lang via options.lang]', () => {
             i18n = new I18N({lang: 'en'});

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -310,11 +310,6 @@ describe('i18n', () => {
 });
 
 describe('constructor options', () => {
-    it('should throw an error in case of languages absence', () => {
-        i18n = new I18N();
-        expect(() => i18n.i18n('notification', 'title')).toThrow();
-    });
-
     describe('lang', () => {
         it('should return translation [set lang via options.lang]', () => {
             i18n = new I18N({lang: 'en'});

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -308,3 +308,90 @@ describe('i18n', () => {
         expect(logger.log).toHaveBeenCalledTimes(callsLength + 1);
     });
 });
+
+describe('constructor options', () => {
+    describe('lang', () => {
+        it('should return translation [set lang via options.lang]', () => {
+            i18n = new I18N({lang: 'en'});
+            i18n.registerKeyset('en', 'notification', {
+                title: 'New version'
+            });
+            expect(i18n.i18n('notification', 'title')).toBe('New version');
+        });
+
+        it('should return translation [set lang via i18n.setLang]', () => {
+            i18n.setLang('en');
+            i18n.registerKeyset('en', 'notification', {
+                title: 'New version'
+            });
+            expect(i18n.i18n('notification', 'title')).toBe('New version');
+        });
+    });
+
+    describe('data', () => {
+        it('should return translation [set data via options.data]', () => {
+            i18n = new I18N({lang: 'en', data: {en: {notification: {title: 'New version'}}}});
+            expect(i18n.i18n('notification', 'title')).toBe('New version');
+        });
+
+        it('should return translation [set data via i18n.registerKeyset]', () => {
+            i18n = new I18N({lang: 'en'});
+            i18n.registerKeyset('en', 'notification', {
+                title: 'New version'
+            });
+            expect(i18n.i18n('notification', 'title')).toBe('New version');
+        });
+    });
+
+    describe('defaultLang', () => {
+        it('should return translation from default language in case of language data absence', () => {
+            i18n = new I18N({
+                lang: 'sr',
+                defaultLang: 'en',
+                data: {en: {notification: {title: 'New version'}}},
+            });
+            expect(i18n.i18n('notification', 'title')).toBe('New version');
+        });
+
+        it('should return fallback from default language in case of language data absence', () => {
+            i18n = new I18N({lang: 'sr', defaultLang: 'en', data: {en: {notification: {}}}});
+            expect(i18n.i18n('notification', 'title')).toBe('title');
+        });
+
+        it('should return translation from default language in case of empty keyset', () => {
+            i18n = new I18N({
+                lang: 'sr',
+                defaultLang: 'en',
+                data: {
+                    en: {notification: {title: 'New version'}},
+                    sr: {notification: {}},
+                },
+            });
+            expect(i18n.i18n('notification', 'title')).toBe('New version');
+        });
+
+        it('should return translation from default language in case of missing key', () => {
+            i18n = new I18N({
+                lang: 'sr',
+                defaultLang: 'en',
+                data: {
+                    en: {notification: {title: 'New version'}},
+                    sr: {notification: {hey: 'Zdravo!'}},
+                },
+            });
+            expect(i18n.i18n('notification', 'title')).toBe('New version');
+        });
+
+        it('should return fallback from default language in case of missing key', () => {
+            i18n = new I18N({
+                lang: 'sr',
+                defaultLang: 'en',
+                data: {
+                    en: {notification: {hey: 'Hello!'}},
+                    sr: {notification: {hey: 'Zdravo!'}},
+                },
+            });
+            expect(i18n.i18n('notification', 'title')).toBe('title');
+        });
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ export class I18N {
 
     i18n(keysetName: string, key: string, params?: Params): string {
         if (!this.lang && !this.fallbackLang) {
-            throw new Error('There are no available languages. You should set at least one of these languages: lang, fallbackLang');
+            throw new Error('Language not specified. You should set at least one of these: "lang", "fallbackLang"');
         }
 
         let text: string | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,7 @@ export class I18N {
         const result = text ?? fallbackText;
         if (result === undefined) {
             const message = mapErrorCodeToMessage({
-                code: details?.code,
+                code: ErrorCode.NoLanguageData,
                 lang: this.lang,
                 fallbackLang: this.fallbackLang,
             });

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ export class I18N {
 
         ({text, fallbackText, details} = this.getTranslationData({keysetName, key, params, lang: this.lang}));
 
-        if (details && details.code !== ErrorCode.NoLanguageData) {
+        if (details) {
             const message = mapErrorCodeToMessage({
                 code: details.code,
                 lang: this.lang,
@@ -163,7 +163,7 @@ export class I18N {
                 lang: this.fallbackLang,
             }));
 
-            if (details && details.code !== ErrorCode.NoLanguageData) {
+            if (details) {
                 const message = mapErrorCodeToMessage({
                     code: details.code,
                     lang: this.fallbackLang,
@@ -172,17 +172,9 @@ export class I18N {
             }
         }
 
-        const result = text ?? fallbackText;
-        if (result === undefined) {
-            const message = mapErrorCodeToMessage({
-                code: ErrorCode.NoLanguageData,
-                lang: this.lang,
-                fallbackLang: this.fallbackLang,
-            });
-            throw new Error(message);
-        }
-
-        return result;
+        // this.getTranslationData method necessarily returns either a `text` or a `fallbackText` value.
+        // Both of these fields are described in the `TranslationData` type as optional so as not to complicate the code.
+        return (text ?? fallbackText) as string;
     }
 
     keyset<TKey extends string = string>(keysetName: string) {
@@ -236,7 +228,10 @@ export class I18N {
         const languageData = this.getLanguageData(lang);
 
         if (typeof languageData === 'undefined') {
-            return {details: {code: ErrorCode.NoLanguageData}};
+            return {
+                fallbackText: key,
+                details: {code: ErrorCode.NoLanguageData}
+            };
         }
 
         if (Object.keys(languageData).length === 0) {
@@ -291,6 +286,7 @@ export class I18N {
 
             const pluralizer = this.getLanguagePluralizer(lang);
             result.text = keyValue[pluralizer(count, PluralForm)] || keyValue[PluralForm.Many];
+
             if (result.text === undefined) {
                 return {
                     fallbackText: key,

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ export class I18N {
 
         ({text, fallbackText, details} = this.getTranslationData({keysetName, key, params, lang: this.lang}));
 
-        if (details && details.code !== ErrorCode.NO_LANGUAGE_DATA) {
+        if (details && details.code !== ErrorCode.NoLanguageData) {
             const message = mapErrorCodeToMessage({
                 code: details.code,
                 lang: this.lang,
@@ -163,7 +163,7 @@ export class I18N {
                 lang: this.fallbackLang,
             }));
 
-            if (details && details.code !== ErrorCode.NO_LANGUAGE_DATA) {
+            if (details && details.code !== ErrorCode.NoLanguageData) {
                 const message = mapErrorCodeToMessage({
                     code: details.code,
                     lang: this.lang,
@@ -236,13 +236,13 @@ export class I18N {
         const languageData = this.getLanguageData(lang);
 
         if (typeof languageData === 'undefined') {
-            return {details: {code: ErrorCode.NO_LANGUAGE_DATA}};
+            return {details: {code: ErrorCode.NoLanguageData}};
         }
 
         if (Object.keys(languageData).length === 0) {
             return {
                 fallbackText: key,
-                details: {code: ErrorCode.EMPTY_LANGUAGE_DATA},
+                details: {code: ErrorCode.EmptyLanguageData},
             };
         }
 
@@ -251,14 +251,14 @@ export class I18N {
         if (!keyset) {
             return {
                 fallbackText: key,
-                details: {code: ErrorCode.KEYSET_NOT_FOUND, keysetName},
+                details: {code: ErrorCode.KeysetNotFound, keysetName},
             };
         }
 
         if (Object.keys(keyset).length === 0) {
             return {
                 fallbackText: key,
-                details: {code: ErrorCode.EMPTY_KEYSET, keysetName},
+                details: {code: ErrorCode.EmptyKeyset, keysetName},
             };
         }
 
@@ -268,7 +268,7 @@ export class I18N {
         if (typeof keyValue === 'undefined') {
             return {
                 fallbackText: key,
-                details: {code: ErrorCode.MISSING_KEY, keysetName, key},
+                details: {code: ErrorCode.MissingKey, keysetName, key},
             };
         }
 
@@ -276,7 +276,7 @@ export class I18N {
             if (keyValue.length < 3) {
                 return {
                     fallbackText: key,
-                    details: {code: ErrorCode.MISSING_REQUIRED_PLURALS, keysetName, key},
+                    details: {code: ErrorCode.MissingKeyPlurals, keysetName, key},
                 };
             }
 
@@ -285,7 +285,7 @@ export class I18N {
             if (Number.isNaN(count)) {
                 return {
                     fallbackText: key,
-                    details: {code: ErrorCode.MISSING_KEY_PARAMS_COUNT, keysetName, key},
+                    details: {code: ErrorCode.MissingKeyParamsCount, keysetName, key},
                 };
             }
 
@@ -294,7 +294,7 @@ export class I18N {
 
             if (keyValue[PluralForm.None] === undefined) {
                 result.details = {
-                    code: ErrorCode.MISSING_KEY_FOR_0,
+                    code: ErrorCode.MissingKeyFor0,
                     keysetName,
                     key,
                 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,11 @@ export class I18N {
 
     i18n(keysetName: string, key: string, params?: Params): string {
         const languages = [this.lang, this.fallbackLang].filter(Boolean) as string[];
+
+        if (!languages.length) {
+            throw new Error('There are no defined languages. You should define at least one of these languages: lang, fallbackLang');
+        }
+
         let text: string | undefined;
         let fallbackText: string | undefined;
         let details: TranslationData['details'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,21 +136,25 @@ export class I18N {
 
     i18n(keysetName: string, key: string, params?: Params): string {
         if (!this.lang && !this.fallbackLang) {
-            throw new Error('Language not specified. You should set at least one of these: "lang", "fallbackLang"');
+            throw new Error('Language is not specified. You should set at least one of these: "lang", "fallbackLang"');
         }
 
         let text: string | undefined;
         let details: TranslationData['details'];
 
-        ({text, details} = this.getTranslationData({keysetName, key, params, lang: this.lang}));
+        if (this.lang) {
+            ({text, details} = this.getTranslationData({keysetName, key, params, lang: this.lang}));
 
-        if (details) {
-            const message = mapErrorCodeToMessage({
-                code: details.code,
-                lang: this.lang,
-                fallbackLang: this.fallbackLang === this.lang ? undefined : this.fallbackLang,
-            });
-            this.warn(message, details.keysetName, details.key);
+            if (details) {
+                const message = mapErrorCodeToMessage({
+                    code: details.code,
+                    lang: this.lang,
+                    fallbackLang: this.fallbackLang === this.lang ? undefined : this.fallbackLang,
+                });
+                this.warn(message, details.keysetName, details.key);
+            }
+        } else {
+            this.warn('Target language is not specified.');
         }
 
         if (text === undefined && this.fallbackLang && this.fallbackLang !== this.lang) {
@@ -217,7 +221,7 @@ export class I18N {
     private getTranslationData(args: {
         keysetName: string;
         key: string;
-        lang?: string;
+        lang: string;
         params?: Params;
     }): TranslationData {
         const {lang, key, keysetName, params} = args;

--- a/src/replace-params.ts
+++ b/src/replace-params.ts
@@ -14,7 +14,7 @@ export function replaceParams(keyValue: string, params: Params): string {
         lastIndex = PARAM_REGEXP.lastIndex;
 
         const [all, key] = match;
-        if (Object.prototype.hasOwnProperty.call(params, key)) {
+        if (key && Object.prototype.hasOwnProperty.call(params, key)) {
             result += params[key];
         } else {
             result += all;

--- a/src/translation-helpers.ts
+++ b/src/translation-helpers.ts
@@ -12,8 +12,8 @@ export const ErrorCode = {
 const codeValues = Object.values(ErrorCode);
 export type ErrorCodeType = (typeof codeValues)[number];
 
-export function mapErrorCodeToMessage(args: {lang: string; defaultLang?: string; code?: ErrorCodeType}) {
-    const {code, defaultLang, lang} = args;
+export function mapErrorCodeToMessage(args: {lang: string; fallbackLang?: string; code?: ErrorCodeType}) {
+    const {code, fallbackLang, lang} = args;
     let message = '';
 
     switch (code) {
@@ -50,8 +50,8 @@ export function mapErrorCodeToMessage(args: {lang: string; defaultLang?: string;
         }
     }
 
-    if (defaultLang) {
-        message += ` Trying to use default language "${defaultLang}"...`;
+    if (fallbackLang) {
+        message += ` Trying to use default language "${fallbackLang}"...`;
     }
 
     return message;

--- a/src/translation-helpers.ts
+++ b/src/translation-helpers.ts
@@ -1,12 +1,12 @@
 export const ErrorCode = {
-    NO_LANGUAGE_DATA: 'NO_LANGUAGE_DATA',
-    EMPTY_LANGUAGE_DATA: 'EMPTY_LANGUAGE_DATA',
-    KEYSET_NOT_FOUND: 'KEYSET_NOT_FOUND',
-    EMPTY_KEYSET: 'EMPTY_KEYSET',
-    MISSING_KEY: 'MISSING_KEY',
-    MISSING_REQUIRED_PLURALS: 'MISSING_REQUIRED_PLURALS',
-    MISSING_KEY_PARAMS_COUNT: 'MISSING_KEY_PARAMS_COUNT',
-    MISSING_KEY_FOR_0: 'MISSING_KEY_FOR_0',
+    EmptyKeyset: 'EMPTY_KEYSET',
+    EmptyLanguageData: 'EMPTY_LANGUAGE_DATA',
+    KeysetNotFound: 'KEYSET_NOT_FOUND',
+    MissingKey: 'MISSING_KEY',
+    MissingKeyFor0: 'MISSING_KEY_FOR_0',
+    MissingKeyParamsCount: 'MISSING_KEY_PARAMS_COUNT',
+    MissingKeyPlurals: 'MISSING_KEY_PLURALS',
+    NoLanguageData: 'NO_LANGUAGE_DATA',
 } as const;
 
 const codeValues = Object.values(ErrorCode);
@@ -41,7 +41,7 @@ export function mapErrorCodeToMessage(args: {lang?: string; fallbackLang?: strin
             message = 'Missing params.count for key.';
             break;
         }
-        case 'MISSING_REQUIRED_PLURALS': {
+        case 'MISSING_KEY_PLURALS': {
             message = 'Missing required plurals';
             break;
         }

--- a/src/translation-helpers.ts
+++ b/src/translation-helpers.ts
@@ -12,37 +12,37 @@ export const ErrorCode = {
 const codeValues = Object.values(ErrorCode);
 export type ErrorCodeType = (typeof codeValues)[number];
 
-export function mapErrorCodeToMessage(args: {code: ErrorCodeType; lang?: string; fallbackLang?: string}) {
+export function mapErrorCodeToMessage(args: {code: ErrorCodeType; lang: string; fallbackLang?: string}) {
     const {code, fallbackLang, lang} = args;
-    let message = '';
+    let message = `Using language ${lang}. `;
 
     switch (code) {
         case ErrorCode.EmptyKeyset: {
-            message = `Keyset is empty.`;
+            message += `Keyset is empty.`;
             break;
         }
         case ErrorCode.EmptyLanguageData: {
-            message = 'Language data is empty.';
+            message += 'Language data is empty.';
             break;
         }
         case ErrorCode.KeysetNotFound: {
-            message = 'Keyset not found.';
+            message += 'Keyset not found.';
             break;
         }
         case ErrorCode.MissingKey: {
-            message = 'Missing key.';
+            message += 'Missing key.';
             break;
         }
         case ErrorCode.MissingKeyFor0: {
-            message = 'Missing key for 0';
-            break;
+            message += 'Missing key for 0';
+            return message
         }
         case ErrorCode.MissingKeyParamsCount: {
-            message = 'Missing params.count for key.';
+            message += 'Missing params.count for key.';
             break;
         }
         case ErrorCode.MissingKeyPlurals: {
-            message = 'Missing required plurals.';
+            message += 'Missing required plurals.';
             break;
         }
         case ErrorCode.NoLanguageData: {

--- a/src/translation-helpers.ts
+++ b/src/translation-helpers.ts
@@ -1,0 +1,58 @@
+export const ErrorCode = {
+    NO_LANGUAGE_DATA: 'NO_LANGUAGE_DATA',
+    EMPTY_LANGUAGE_DATA: 'EMPTY_LANGUAGE_DATA',
+    KEYSET_NOT_FOUND: 'KEYSET_NOT_FOUND',
+    EMPTY_KEYSET: 'EMPTY_KEYSET',
+    MISSING_KEY: 'MISSING_KEY',
+    MISSING_REQUIRED_PLURALS: 'MISSING_REQUIRED_PLURALS',
+    MISSING_KEY_PARAMS_COUNT: 'MISSING_KEY_PARAMS_COUNT',
+    MISSING_KEY_FOR_0: 'MISSING_KEY_FOR_0',
+} as const;
+
+const codeValues = Object.values(ErrorCode);
+export type ErrorCodeType = (typeof codeValues)[number];
+
+export function mapErrorCodeToMessage(args: {lang: string; defaultLang?: string; code?: ErrorCodeType}) {
+    const {code, defaultLang, lang} = args;
+    let message = '';
+
+    switch (code) {
+        case 'EMPTY_KEYSET': {
+            message = `Keyset is empty.`;
+            break;
+        }
+        case 'EMPTY_LANGUAGE_DATA': {
+            message = 'Language data is empty.';
+            break;
+        }
+        case 'KEYSET_NOT_FOUND': {
+            message = 'Keyset not found.';
+            break;
+        }
+        case 'MISSING_KEY': {
+            message = 'Missing key.';
+            break;
+        }
+        case 'MISSING_KEY_FOR_0': {
+            message = 'Missing key for 0';
+            break;
+        }
+        case 'MISSING_KEY_PARAMS_COUNT': {
+            message = 'Missing params.count for key.';
+            break;
+        }
+        case 'MISSING_REQUIRED_PLURALS': {
+            message = 'Missing required plurals';
+            break;
+        }
+        case 'NO_LANGUAGE_DATA': {
+            message = `Language "${lang}" is not defined, make sure you call setLang for the same language you called registerKeysets for!`;
+        }
+    }
+
+    if (defaultLang) {
+        message += ` Trying to use default language "${defaultLang}"...`;
+    }
+
+    return message;
+}

--- a/src/translation-helpers.ts
+++ b/src/translation-helpers.ts
@@ -42,7 +42,7 @@ export function mapErrorCodeToMessage(args: {lang?: string; fallbackLang?: strin
             break;
         }
         case ErrorCode.MissingKeyPlurals: {
-            message = 'Missing required plurals';
+            message = 'Missing required plurals.';
             break;
         }
         case ErrorCode.NoLanguageData: {
@@ -51,7 +51,7 @@ export function mapErrorCodeToMessage(args: {lang?: string; fallbackLang?: strin
     }
 
     if (fallbackLang) {
-        message += ` Trying to use default language "${fallbackLang}"...`;
+        message += ` Trying to use fallback language "${fallbackLang}"...`;
     }
 
     return message;

--- a/src/translation-helpers.ts
+++ b/src/translation-helpers.ts
@@ -12,7 +12,7 @@ export const ErrorCode = {
 const codeValues = Object.values(ErrorCode);
 export type ErrorCodeType = (typeof codeValues)[number];
 
-export function mapErrorCodeToMessage(args: {lang: string; fallbackLang?: string; code?: ErrorCodeType}) {
+export function mapErrorCodeToMessage(args: {lang?: string; fallbackLang?: string; code?: ErrorCodeType}) {
     const {code, fallbackLang, lang} = args;
     let message = '';
 

--- a/src/translation-helpers.ts
+++ b/src/translation-helpers.ts
@@ -17,35 +17,35 @@ export function mapErrorCodeToMessage(args: {lang?: string; fallbackLang?: strin
     let message = '';
 
     switch (code) {
-        case 'EMPTY_KEYSET': {
+        case ErrorCode.EmptyKeyset: {
             message = `Keyset is empty.`;
             break;
         }
-        case 'EMPTY_LANGUAGE_DATA': {
+        case ErrorCode.EmptyLanguageData: {
             message = 'Language data is empty.';
             break;
         }
-        case 'KEYSET_NOT_FOUND': {
+        case ErrorCode.KeysetNotFound: {
             message = 'Keyset not found.';
             break;
         }
-        case 'MISSING_KEY': {
+        case ErrorCode.MissingKey: {
             message = 'Missing key.';
             break;
         }
-        case 'MISSING_KEY_FOR_0': {
+        case ErrorCode.MissingKeyFor0: {
             message = 'Missing key for 0';
             break;
         }
-        case 'MISSING_KEY_PARAMS_COUNT': {
+        case ErrorCode.MissingKeyParamsCount: {
             message = 'Missing params.count for key.';
             break;
         }
-        case 'MISSING_KEY_PLURALS': {
+        case ErrorCode.MissingKeyPlurals: {
             message = 'Missing required plurals';
             break;
         }
-        case 'NO_LANGUAGE_DATA': {
+        case ErrorCode.NoLanguageData: {
             message = `Language "${lang}" is not defined, make sure you call setLang for the same language you called registerKeysets for!`;
         }
     }

--- a/src/translation-helpers.ts
+++ b/src/translation-helpers.ts
@@ -12,7 +12,7 @@ export const ErrorCode = {
 const codeValues = Object.values(ErrorCode);
 export type ErrorCodeType = (typeof codeValues)[number];
 
-export function mapErrorCodeToMessage(args: {lang?: string; fallbackLang?: string; code?: ErrorCodeType}) {
+export function mapErrorCodeToMessage(args: {code: ErrorCodeType; lang?: string; fallbackLang?: string}) {
     const {code, fallbackLang, lang} = args;
     let message = '';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "esnext",
     "baseUrl": ".",
     "importHelpers": true,
-    "declaration": true
+    "declaration": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/*.ts"],
   "exclude": ["**/*.spec.ts"]


### PR DESCRIPTION
Add new arguments for I18N constructor:
- `data` - keysets mapped data
- `fallbackLang` - language used as fallback in case there is no translation in the target language
- `lang` - target language for the i18n instance

Previous PR - https://github.com/gravity-ui/i18n/pull/39