### PR TITLE
feat: use Intl.PluralRules for plural keys

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -307,6 +307,170 @@ describe('i18n', () => {
 
         expect(logger.log).toHaveBeenCalledTimes(callsLength + 1);
     });
+
+    it('add description for test new plural form', () => {
+        i18n.setLang('ru');
+        i18n.registerKeyset('ru', 'app', {
+            users: {
+                'zero': 'нет пользователей',
+                'other': 'sdf',
+                'one': '{{count}} пользователь',
+                'few': '{{count}} пользователя',
+                'many': '{{count}} пользователей',
+            }
+        });
+
+        expect(i18n.i18n('app', 'users', {
+            count: 0
+        })).toBe('нет пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 1
+        })).toBe('1 пользователь');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 2
+        })).toBe('2 пользователя');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 3
+        })).toBe('3 пользователя');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 5
+        })).toBe('5 пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 11
+        })).toBe('11 пользователей');
+    });
+
+    it('should throw exception when missing required plural form', () => {
+        i18n.setLang('ru');
+        i18n.registerKeyset('ru', 'app', {
+            // @ts-ignore
+            users: {'many': '{{count}} пользователей'}
+        });
+
+        expect(() => {
+            i18n.i18n('app', 'users', {
+                count: 11,
+            })
+        }).toThrow(new Error(`Missing required plural form 'other' for key 'users'`));
+    });
+
+    it('should use `other` form when no other forms are specified', () => {
+        i18n.setLang('ru');
+        i18n.registerKeyset('ru', 'app', {
+            users: {'other': '{{count}} пользователей'}
+        });
+
+        expect(i18n.i18n('app', 'users', {
+            count: 21,
+        })).toBe('21 пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 0,
+        })).toBe('0 пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 10,
+        })).toBe('10 пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 2,
+        })).toBe('2 пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 1,
+        })).toBe('1 пользователей');
+    });
+
+    it('should use `other` form when no other forms are specified', () => {
+        i18n.setLang('ru');
+        i18n.registerKeyset('ru', 'app', {
+            users: {'other': '{{count}} пользователей'},
+            articles: {'one': '{{count}} статья', 'other': '{{count}} статей'},
+        });
+
+        expect(i18n.i18n('app', 'users', {
+            count: 21,
+        })).toBe('21 пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 0,
+        })).toBe('0 пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 10,
+        })).toBe('10 пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 2,
+        })).toBe('2 пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 1,
+        })).toBe('1 пользователей');
+
+        expect(i18n.i18n('app', 'articles', {
+            count: 1,
+        })).toBe('1 статья');
+
+        expect(i18n.i18n('app', 'articles', {
+            count: 21,
+        })).toBe('21 статья');
+
+        expect(i18n.i18n('app', 'articles', {
+            count: 0,
+        })).toBe('0 статей');
+
+        expect(i18n.i18n('app', 'articles', {
+            count: 5,
+        })).toBe('5 статей');
+
+        expect(i18n.i18n('app', 'articles', {
+            count: 3,
+        })).toBe('3 статей');
+    });
+
+    it('compare with depricated pluralizer', () => {
+        i18n.setLang('ru');
+        i18n.registerKeyset('ru', 'app', {
+            users_old: ['нет пользователей', '{{count}} пользователь', '{{count}} пользователя', '{{count}} пользователей'],
+            users: {
+                'zero': 'нет пользователей',
+                'one': '{{count}} пользователь',
+                'few': '{{count}} пользователя',
+                'many': '{{count}} пользователей',
+                'other': '',
+            },
+        });
+
+        expect(i18n.i18n('app', 'users', {
+            count: 0
+        })).toBe('нет пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 1
+        })).toBe('1 пользователь');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 2
+        })).toBe('2 пользователя');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 3
+        })).toBe('3 пользователя');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 5
+        })).toBe('5 пользователей');
+
+        expect(i18n.i18n('app', 'users', {
+            count: 11
+        })).toBe('11 пользователей');
+    });
 });
 
 describe('constructor options', () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -308,16 +308,16 @@ describe('i18n', () => {
         expect(logger.log).toHaveBeenCalledTimes(callsLength + 1);
     });
 
-    it('add description for test new plural form', () => {
+    it('basic checks for plurals with Intl.PluralRules', () => {
         i18n.setLang('ru');
         i18n.registerKeyset('ru', 'app', {
             users: {
                 'zero': 'нет пользователей',
-                'other': 'sdf',
                 'one': '{{count}} пользователь',
                 'few': '{{count}} пользователя',
                 'many': '{{count}} пользователей',
-            }
+                'other': '',
+            },
         });
 
         expect(i18n.i18n('app', 'users', {
@@ -434,10 +434,15 @@ describe('i18n', () => {
         })).toBe('3 статей');
     });
 
-    it('compare with depricated pluralizer', () => {
+    it('compare results between old and new plural formats', () => {
         i18n.setLang('ru');
         i18n.registerKeyset('ru', 'app', {
-            users_old: ['нет пользователей', '{{count}} пользователь', '{{count}} пользователя', '{{count}} пользователей'],
+            usersOldPlural: [
+                '{{count}} пользователь',
+                '{{count}} пользователя',
+                '{{count}} пользователей',
+                'нет пользователей',
+            ],
             users: {
                 'zero': 'нет пользователей',
                 'one': '{{count}} пользователь',
@@ -449,27 +454,39 @@ describe('i18n', () => {
 
         expect(i18n.i18n('app', 'users', {
             count: 0
-        })).toBe('нет пользователей');
+        })).toBe(i18n.i18n('app', 'usersOldPlural', {
+            count: 0
+        }));
 
         expect(i18n.i18n('app', 'users', {
             count: 1
-        })).toBe('1 пользователь');
+        })).toBe(i18n.i18n('app', 'usersOldPlural', {
+            count: 1
+        }));
 
         expect(i18n.i18n('app', 'users', {
             count: 2
-        })).toBe('2 пользователя');
+        })).toBe(i18n.i18n('app', 'usersOldPlural', {
+            count: 2
+        }));
 
         expect(i18n.i18n('app', 'users', {
             count: 3
-        })).toBe('3 пользователя');
+        })).toBe(i18n.i18n('app', 'usersOldPlural', {
+            count: 3
+        }));
 
         expect(i18n.i18n('app', 'users', {
             count: 5
-        })).toBe('5 пользователей');
+        })).toBe(i18n.i18n('app', 'usersOldPlural', {
+            count: 5
+        }));
 
         expect(i18n.i18n('app', 'users', {
             count: 11
-        })).toBe('11 пользователей');
+        })).toBe(i18n.i18n('app', 'usersOldPlural', {
+            count: 11
+        }));
     });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import {replaceParams} from './replace-params';
 import {ErrorCode, mapErrorCodeToMessage} from './translation-helpers';
 import type {ErrorCodeType} from './translation-helpers';
-import {PluralForm} from './types';
+import {isPluralValue} from './types';
 import type {KeysData, KeysetData, Logger, Params, Pluralizer} from './types';
+
 import pluralizerEn from './plural/en';
 import pluralizerRu from './plural/ru';
+import {getPluralValue} from './plural/general';
 
 export * from './types';
 
@@ -124,7 +126,7 @@ export class I18N {
         } else if (isAlreadyRegistered) {
             this.warn(`Keyset '${keysetName}' is already registered.`);
         }
-        
+
         this.data[lang] = Object.assign({}, this.data[lang], {[keysetName]: data});
     }
 
@@ -216,14 +218,6 @@ export class I18N {
         return langCode ? this.data[langCode] : undefined;
     }
 
-    protected getLanguagePluralizer(lang?: string): Pluralizer {
-        const pluralizer = lang ? this.pluralizers[lang] : undefined;
-        if (!pluralizer) {
-            this.warn(`Pluralization is not configured for language '${lang}', falling back to the english ruleset`);
-        }
-        return pluralizer || pluralizerEn;
-    }
-
     private getTranslationData(args: {
         keysetName: string;
         key: string;
@@ -258,27 +252,21 @@ export class I18N {
             return {details: {code: ErrorCode.MissingKey, keysetName, key}};
         }
 
-        if (Array.isArray(keyValue)) {
-            if (keyValue.length < 3) {
-                return {details: {code: ErrorCode.MissingKeyPlurals, keysetName, key}};
-            }
-
+        if (isPluralValue(keyValue)) {
             const count = Number(params?.count);
 
             if (Number.isNaN(count)) {
                 return {details: {code: ErrorCode.MissingKeyParamsCount, keysetName, key}};
             }
 
-            const pluralizer = this.getLanguagePluralizer(lang);
-            result.text = keyValue[pluralizer(count, PluralForm)] || keyValue[PluralForm.Many];
-
-            if (result.text === undefined) {
-                return {details: {code: ErrorCode.MissingKeyPlurals, keysetName, key}};
-            }
-
-            if (keyValue[PluralForm.None] === undefined) {
-                result.details = {code: ErrorCode.MissingKeyFor0, keysetName, key};
-            }
+            result.text = getPluralValue({
+                key,
+                value: keyValue,
+                count,
+                lang: this.lang || 'en',
+                pluralizers: this.pluralizers,
+                log: (message) => this.warn(message, keysetName, key),
+            });
         } else {
             result.text = keyValue;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,9 @@ export class I18N {
         this.fallbackLang = fallbackLang;
     }
 
+    /**
+     * @deprecated Plurals automatically used from Intl.PluralRules. You can safely remove this call. Will be removed in v2.
+     */
     configurePluralization(pluralizers: Record<string, Pluralizer>) {
         this.pluralizers = Object.assign({}, this.pluralizers, pluralizers);
     }

--- a/src/plural/general.ts
+++ b/src/plural/general.ts
@@ -1,0 +1,58 @@
+import type { DeprecatedPluralValue, PluralValue, Pluralizer } from "../types";
+import {PluralForm} from '../types';
+
+export function getPluralViaIntl(key: string, value: PluralValue, count: number, lang: string) {
+    if (typeof value.other === 'undefined') {
+        throw new Error(`Missing required plural form 'other' for key '${key}'`);
+    }
+
+    if (value.zero && count === 0) {
+        return value.zero;
+    }
+
+    if (!Intl.PluralRules) {
+        throw new Error('Intl.PluralRules is not available. Use polyfill.');
+    }
+
+    const pluralRules = new Intl.PluralRules(lang);
+    return value[pluralRules.select(count)] || value.other;
+}
+
+type FormatPluralArgs = {
+    key: string;
+    value: DeprecatedPluralValue | PluralValue;
+    fallbackValue?: string;
+    count: number;
+    lang: string;
+    pluralizers?: Record<string, Pluralizer>;
+    log: (message: string) => void;
+}
+
+export function getPluralValue({value, count, lang, pluralizers, log, key}: FormatPluralArgs) {
+    if (!Array.isArray(value)) {
+        return getPluralViaIntl(key, value, count, lang) || key;
+    }
+
+    if (!pluralizers) {
+        log('Can not use deprecated plural format without pluralizers');
+        return key;
+    }
+
+    if (!pluralizers[lang]) {
+        log(`Pluralization is not configured for language '${lang}', falling back to the english ruleset`);
+    }
+
+    if (value.length < 3) {
+        log('Missing required plurals');
+        return key;
+    }
+
+    const pluralizer = pluralizers[lang] || pluralizers['en'];
+
+    if (!pluralizer) {
+        log('Fallback pluralization is not configured!');
+        return key;
+    }
+
+    return value[pluralizer(count, PluralForm)] || value[PluralForm.Many] || key;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-export type KeysData = Record<string, string | string[]>;
+export type KeyData = string | DeprecatedPluralValue | PluralValue;
+export type KeysData = Record<string, KeyData>;
 export type KeysetData = Record<string, KeysData>;
 
 type NoEnumLikeStringLiteral<T> = string extends T ? T : never;
@@ -59,6 +60,21 @@ export enum PluralForm {
     Few,
     Many,
     None
+}
+
+export type DeprecatedPluralValue = string[]
+
+export type PluralValue = {
+    zero?: string;
+    one?: string;
+    two?: string;
+    few?: string;
+    many?: string;
+    other: string;
+}
+
+export function isPluralValue(value: KeyData): value is DeprecatedPluralValue | PluralValue {
+    return typeof value !== 'string';
 }
 
 export interface Logger {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,9 @@ export enum PluralForm {
     None
 }
 
+/**
+ * @deprecated Old plurals format. Use new format from type PluralValue. Will be removed in v2.
+ */
 export type DeprecatedPluralValue = string[]
 
 export type PluralValue = {


### PR DESCRIPTION
Now plural format can be:
```json
{
	"one": "{{count}} thing",
	"zero": "Nothing found",
	"other": "{{count}} things",
}
```