### PR TITLE
feat: validate namespace and key

### DIFF
--- a/packages/eslint-plugin-i18n/rules/__tests__/auto-generate-translation-message-id.spec.ts
+++ b/packages/eslint-plugin-i18n/rules/__tests__/auto-generate-translation-message-id.spec.ts
@@ -338,6 +338,285 @@ describe('Rule auto-generate-translation-message-id', () => {
         // });
     });
 
+    describe('validation of existing IDs', () => {
+        const options: Partial<RuleOptions>[] = [
+            {
+                memberExpressions: [{member: 'intl', property: 'createMessages'}],
+                namespaceMatchers: [/\/([^/]+)\/[^/]*i18n\.ts$/],
+                validateId: true, // Enable validation for these tests
+            },
+        ];
+
+        describe('should not validate by default (validateId not specified)', () => {
+            const defaultOptions: Partial<RuleOptions>[] = [
+                {
+                    memberExpressions: [{member: 'intl', property: 'createMessages'}],
+                    namespaceMatchers: [/\/([^/]+)\/[^/]*i18n\.ts$/],
+                    // validateId not specified - should default to false
+                },
+            ];
+
+            const validCases = [
+                {
+                    name: 'wrong namespace but validation disabled by default',
+                    code: `intl.createMessages({
+                        field_description: {
+                            en: 'Description',
+                            meta: {
+                                id: 'agent.field_description:9ntzU',
+                            }
+                        }
+                    })`,
+                    filename: '/src/ui/modules/issue/i18n.ts',
+                    options: defaultOptions,
+                },
+            ];
+
+            runTests(validCases, []);
+        });
+
+        describe('should detect invalid namespace prefix', () => {
+            const invalidCases = [
+                {
+                    name: 'wrong namespace in id',
+                    code: `intl.createMessages({
+                        field_description: {
+                            en: 'Description',
+                            meta: {
+                                id: 'agent.field_description:9ntzU',
+                            }
+                        }
+                    })`,
+                    filename: '/src/ui/modules/issue/i18n.ts',
+                    options,
+                    errors: [
+                        {
+                            message:
+                                'Invalid namespace "agent" in ID. Expected "issue" based on file path "/src/ui/modules/issue/i18n.ts"',
+                        },
+                    ],
+                    output: `intl.createMessages({
+                        field_description: {
+                            en: 'Description',
+                            meta: {
+                                id: 'issue.field_description${TRANSLATION_OBJECT_KEY_AND_UUID_SEPARATOR}${UUID}',
+                            }
+                        }
+                    })`,
+                },
+            ];
+
+            runTests([], invalidCases);
+        });
+
+        describe('should detect invalid key in id', () => {
+            const invalidCases = [
+                {
+                    name: 'key mismatch',
+                    code: `intl.createMessages({
+                        field_description: {
+                            en: 'Description',
+                            meta: {
+                                id: 'issue.field_title:9ntzU',
+                            }
+                        }
+                    })`,
+                    filename: '/src/ui/modules/issue/i18n.ts',
+                    options,
+                    errors: [
+                        {
+                            message:
+                                'Invalid key "field_title" in ID. Expected "field_description" to match translation key "field_description"',
+                        },
+                    ],
+                    output: `intl.createMessages({
+                        field_description: {
+                            en: 'Description',
+                            meta: {
+                                id: 'issue.field_description${TRANSLATION_OBJECT_KEY_AND_UUID_SEPARATOR}${UUID}',
+                            }
+                        }
+                    })`,
+                },
+            ];
+
+            runTests([], invalidCases);
+        });
+
+        describe('should detect invalid ID format', () => {
+            const invalidCases = [
+                {
+                    name: 'malformed id',
+                    code: `intl.createMessages({
+                        field_description: {
+                            en: 'Description',
+                            meta: {
+                                id: 'invalid-format',
+                            }
+                        }
+                    })`,
+                    filename: '/src/ui/modules/issue/i18n.ts',
+                    options,
+                    errors: [
+                        {
+                            message:
+                                'Invalid ID format "invalid-format". Expected format: namespace.key:uuid',
+                        },
+                    ],
+                    output: `intl.createMessages({
+                        field_description: {
+                            en: 'Description',
+                            meta: {
+                                id: 'issue.field_description${TRANSLATION_OBJECT_KEY_AND_UUID_SEPARATOR}${UUID}',
+                            }
+                        }
+                    })`,
+                },
+            ];
+
+            runTests([], invalidCases);
+        });
+
+        describe('should replace existing id value, not add duplicate', () => {
+            const invalidCases = [
+                {
+                    name: 'copied key with wrong id',
+                    code: `intl.createMessages({
+                        'action_close-issue': {
+                            en: 'Close issue',
+                            meta: {
+                                id: 'issue.action_close-issue:xd1Kb',
+                            }
+                        },
+                        'action_close-issue3': {
+                            en: 'Close issue',
+                            meta: {
+                                id: 'issue.action_close-issue:xd1Kb',
+                            }
+                        }
+                    })`,
+                    filename: '/src/ui/modules/issue/i18n.ts',
+                    options,
+                    errors: [
+                        {
+                            message:
+                                'Invalid key "action_close-issue" in ID. Expected "action_close-issue3" to match translation key "action_close-issue3"',
+                        },
+                    ],
+                    output: `intl.createMessages({
+                        'action_close-issue': {
+                            en: 'Close issue',
+                            meta: {
+                                id: 'issue.action_close-issue:xd1Kb',
+                            }
+                        },
+                        'action_close-issue3': {
+                            en: 'Close issue',
+                            meta: {
+                                id: 'issue.action_close-issue3${TRANSLATION_OBJECT_KEY_AND_UUID_SEPARATOR}${UUID}',
+                            }
+                        }
+                    })`,
+                },
+            ];
+
+            runTests([], invalidCases);
+        });
+
+        describe('should not error on valid IDs', () => {
+            const validCases = [
+                {
+                    name: 'correct namespace and key',
+                    code: `intl.createMessages({
+                        field_description: {
+                            en: 'Description',
+                            meta: {
+                                id: 'issue.field_description:9ntzU',
+                            }
+                        }
+                    })`,
+                    filename: '/src/ui/modules/issue/i18n.ts',
+                    options,
+                },
+            ];
+
+            runTests(validCases, []);
+        });
+
+        describe('should handle kebab-case keys with underscores in IDs', () => {
+            const validCases = [
+                {
+                    name: 'kebab-case key with underscore in id',
+                    code: `intl.createMessages({
+                        'action_close-issue': {
+                            en: 'Close issue',
+                            meta: {
+                                id: 'issue.action_close-issue:xd1Kb',
+                            }
+                        }
+                    })`,
+                    filename: '/src/ui/modules/issue/i18n.ts',
+                    options,
+                },
+            ];
+
+            runTests(validCases, []);
+        });
+
+        describe('with validateId disabled', () => {
+            const testOptions: Partial<RuleOptions>[] = [
+                {
+                    memberExpressions: [{member: 'intl', property: 'createMessages'}],
+                    namespaceMatchers: [/\/([^/]+)\/[^/]*i18n\.ts$/],
+                    validateId: false,
+                },
+            ];
+
+            describe('should allow wrong namespace and key when validation disabled', () => {
+                const validCases = [
+                    {
+                        name: 'wrong namespace and key but validation disabled',
+                        code: `intl.createMessages({
+                            field_description: {
+                                en: 'Description',
+                                meta: {
+                                    id: 'agent.field_title:9ntzU',
+                                }
+                            }
+                        })`,
+                        filename: '/src/ui/modules/issue/i18n.ts',
+                        options: testOptions,
+                    },
+                ];
+
+                runTests(validCases, []);
+            });
+
+            describe('should still add missing IDs when validation disabled', () => {
+                const invalidCases = [
+                    {
+                        name: 'missing id, validation disabled',
+                        code: `intl.createMessages({
+                            field_description: {
+                                en: 'Description',
+                            }
+                        })`,
+                        filename: '/src/ui/modules/issue/i18n.ts',
+                        options: testOptions,
+                        errors: [{message: 'Expression should have id property'}],
+                        output: `intl.createMessages({
+                            field_description: {meta:{id:'issue.field_description${TRANSLATION_OBJECT_KEY_AND_UUID_SEPARATOR}${UUID}'},
+                                en: 'Description',
+                            }
+                        })`,
+                    },
+                ];
+
+                runTests([], invalidCases);
+            });
+        });
+    });
+
     // Skipped: ESLint 9 requires rule options to be serializable, functions cannot be cloned
     // describe('with generateId function', () => {
     //     const generatedIdMock = 'generated';

--- a/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/handlers/messages-expression.ts
+++ b/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/handlers/messages-expression.ts
@@ -115,14 +115,16 @@ export const getMessagesExpression = ({
                 ...rest,
                 context,
 
-                reportLackId({context, node, id}) {
+                reportLackId({context, node, id, message}) {
                     if (translation && !isArgumentObject) {
                         return;
                     }
 
+                    const reportMessage = message || `Expression should have ${idName} property`;
+
                     context.report({
                         node,
-                        message: `Expression should have ${idName} property`,
+                        message: reportMessage,
                         fix(fixer) {
                             if (!translation) {
                                 return null;
@@ -135,6 +137,18 @@ export const getMessagesExpression = ({
                                 );
                             }
 
+                            // Re-check for id property in case it was added by another fix
+                            const currentIdProperty = getObjectProperty({
+                                argument: metaProperty?.value,
+                                propertyName: idName,
+                            });
+
+                            // If there's an existing id property, replace its value
+                            if (currentIdProperty) {
+                                return fixer.replaceText(currentIdProperty.value, `'${id}'`);
+                            }
+
+                            // Otherwise add the id property to the meta object
                             return fixer.replaceText(
                                 metaProperty,
                                 `${sourceCode.getText(metaProperty).replace('{', `{${idName}:'${id}',`)}`,

--- a/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/index.ts
+++ b/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/index.ts
@@ -23,6 +23,7 @@ export const rule: Rule.RuleModule = {
                     callExpressions: {type: 'array'},
                     idName: {type: 'string'},
                     namespaceMatchers: {type: 'array'},
+                    validateId: {type: 'boolean'},
                 },
             },
         ],
@@ -39,6 +40,7 @@ export const rule: Rule.RuleModule = {
             invalidCharsPattern,
             invalidCharsReplacement,
             invalidCharsReplacer,
+            validateId,
         }: RuleOptions = context.options[0] || {};
 
         const baseParameters: BaseRuleOptions = {
@@ -50,6 +52,7 @@ export const rule: Rule.RuleModule = {
             invalidCharsPattern,
             invalidCharsReplacement,
             invalidCharsReplacer,
+            validateId,
         };
 
         const handler = getMessagesExpression({

--- a/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/types/BaseRuleOptions.ts
+++ b/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/types/BaseRuleOptions.ts
@@ -12,4 +12,5 @@ export interface BaseRuleOptions {
     invalidCharsPattern: RegExp;
     invalidCharsReplacement: string;
     invalidCharsReplacer: (substring: string) => string;
+    validateId?: boolean;
 }

--- a/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/types/handlers/ReportDecorator.ts
+++ b/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/types/handlers/ReportDecorator.ts
@@ -4,4 +4,5 @@ export interface ReportDecorator<T> {
     context: Rule.RuleContext;
     node: T;
     id: string;
+    message?: string;
 }

--- a/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/types/utils/CheckIdProps.ts
+++ b/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/types/utils/CheckIdProps.ts
@@ -14,4 +14,5 @@ export interface CheckIdProps extends BaseRuleOptions {
     currentIdValue: string;
     translationObjectKey?: string;
     node: Node;
+    validateId?: boolean;
 }

--- a/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/utils/__tests__/parse-id.spec.ts
+++ b/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/utils/__tests__/parse-id.spec.ts
@@ -1,0 +1,64 @@
+import {parseId} from '../parse-id';
+
+describe('parseId', () => {
+    it('should parse id without namespace', () => {
+        expect(parseId('create:5251Z')).toEqual({
+            namespace: '',
+            key: 'create',
+            uuid: '5251Z',
+            raw: 'create:5251Z',
+        });
+    });
+
+    it('should parse id with simple namespace', () => {
+        expect(parseId('issue.field_description:9ntzU')).toEqual({
+            namespace: 'issue',
+            key: 'field_description',
+            uuid: '9ntzU',
+            raw: 'issue.field_description:9ntzU',
+        });
+    });
+
+    it('should parse id with compound namespace', () => {
+        expect(parseId('audit-trails.Trail.create:5251Z')).toEqual({
+            namespace: 'audit-trails.Trail',
+            key: 'create',
+            uuid: '5251Z',
+            raw: 'audit-trails.Trail.create:5251Z',
+        });
+    });
+
+    it('should parse id with kebab-case key', () => {
+        expect(parseId('issue.action_close-issue:xd1Kb')).toEqual({
+            namespace: 'issue',
+            key: 'action_close-issue',
+            uuid: 'xd1Kb',
+            raw: 'issue.action_close-issue:xd1Kb',
+        });
+    });
+
+    it('should return null for invalid format without colon', () => {
+        expect(parseId('invalid-format')).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+        expect(parseId('')).toBeNull();
+    });
+
+    it('should return null for id without key', () => {
+        expect(parseId('namespace.:uuid')).toBeNull();
+    });
+
+    it('should return null for id without uuid', () => {
+        expect(parseId('namespace.key:')).toBeNull();
+    });
+
+    it('should handle complex namespace with multiple dots', () => {
+        expect(parseId('a.b.c.d.key:uuid')).toEqual({
+            namespace: 'a.b.c.d',
+            key: 'key',
+            uuid: 'uuid',
+            raw: 'a.b.c.d.key:uuid',
+        });
+    });
+});

--- a/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/utils/check-id.ts
+++ b/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/utils/check-id.ts
@@ -11,6 +11,7 @@ import {buildId} from './build-id';
 import {checkGenerateId} from './check-generate-id';
 import {defaultReportMaxValidLengthExceeded} from './default-reporters';
 import {getNamespace} from './get-namespace';
+import {parseId} from './parse-id';
 
 export const checkId = ({
     reportLackId,
@@ -26,6 +27,7 @@ export const checkId = ({
     invalidCharsPattern = DEFAULT_INVALID_CHARS_PATTERN,
     invalidCharsReplacement = DEFAULT_INVALID_CHARS_REPLACEMENT,
     invalidCharsReplacer,
+    validateId = false,
 }: Omit<CheckIdProps, 'idName'>) => {
     const filename = context.getFilename();
 
@@ -55,18 +57,55 @@ export const checkId = ({
 
     const id = buildId({uuid, namespace, translationObjectKey});
 
-    if (!hasId) {
-        if (id.length > maxValidLength) {
-            reportMaxValidLengthExceeded({context, node, maxValidLength});
-            return;
-        }
+    // Check if generated ID exceeds max length
+    if (id.length > maxValidLength) {
+        reportMaxValidLengthExceeded({context, node, maxValidLength});
+        return;
+    }
 
+    if (!hasId) {
+        // No ID exists, report to add one
         reportLackId({context, node, id});
         return;
     }
 
-    if (id.length > maxValidLength) {
-        reportMaxValidLengthExceeded({context, node, maxValidLength});
-        return;
+    // ID exists - validate it (only if validation is enabled)
+    if (currentIdValue && validateId) {
+        const parsedId = parseId(currentIdValue);
+
+        // Check if ID is parseable
+        if (!parsedId) {
+            reportLackId({
+                context,
+                node,
+                id,
+                message: `Invalid ID format "${currentIdValue}". Expected format: namespace.key:uuid`,
+            });
+            return;
+        }
+
+        // Check if namespace matches
+        if (namespace && parsedId.namespace !== namespace) {
+            reportLackId({
+                context,
+                node,
+                id,
+                message: `Invalid namespace "${parsedId.namespace}" in ID. Expected "${namespace}" based on file path "${filename}"`,
+            });
+            return;
+        }
+
+        // Check if key matches
+        // Sanitize translationObjectKey same way as build-id does
+        const sanitizedKey = translationObjectKey?.replace(/\./g, '_');
+        if (sanitizedKey && parsedId.key !== sanitizedKey) {
+            reportLackId({
+                context,
+                node,
+                id,
+                message: `Invalid key "${parsedId.key}" in ID. Expected "${sanitizedKey}" to match translation key "${translationObjectKey}"`,
+            });
+            return;
+        }
     }
 };

--- a/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/utils/parse-id.ts
+++ b/packages/eslint-plugin-i18n/rules/auto-generate-translation-message-id/utils/parse-id.ts
@@ -1,0 +1,63 @@
+import {ID_SEPARATOR, TRANSLATION_OBJECT_KEY_AND_UUID_SEPARATOR} from '../constants';
+
+export interface ParsedId {
+    namespace: string;
+    key: string;
+    uuid: string;
+    raw: string;
+}
+
+/**
+ * Parses an i18n ID into its components
+ * Format: key:uuid or namespace.key:uuid or namespace.sub-namespace.key:uuid
+ * Examples:
+ *   "create:5251Z" (no namespace)
+ *   "issue.field_description:9ntzU"
+ *   "audit-trails.Trail.create:5251Z"
+ */
+export const parseId = (id: string): ParsedId | null => {
+    if (!id || typeof id !== 'string') {
+        return null;
+    }
+
+    // First, split by ':' to separate uuid
+    const colonIndex = id.lastIndexOf(TRANSLATION_OBJECT_KEY_AND_UUID_SEPARATOR);
+    if (colonIndex === -1) {
+        return null;
+    }
+
+    const uuid = id.substring(colonIndex + 1);
+    const namespaceAndKey = id.substring(0, colonIndex);
+
+    if (!uuid || !namespaceAndKey) {
+        return null;
+    }
+
+    // Now split by '.' to get namespace and key parts
+    // The key is the last part after the last dot
+    const lastDotIndex = namespaceAndKey.lastIndexOf(ID_SEPARATOR);
+
+    // If no dot found, the entire string is the key (no namespace)
+    if (lastDotIndex === -1) {
+        return {
+            namespace: '',
+            key: namespaceAndKey,
+            uuid,
+            raw: id,
+        };
+    }
+
+    const namespace = namespaceAndKey.substring(0, lastDotIndex);
+    const key = namespaceAndKey.substring(lastDotIndex + 1);
+
+    if (!key) {
+        return null;
+    }
+
+    return {
+        namespace,
+        key, // Keep as-is from the ID (already sanitized)
+        uuid,
+        raw: id,
+    };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,10 +624,6 @@ importers:
         version: 5.9.3
 
   packages/vscode-extension:
-    dependencies:
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
     devDependencies:
       '@types/mocha':
         specifier: ^10.0.10


### PR DESCRIPTION
🎯 Summary

Add optional ID validation to @gravity-ui/eslint-plugin-i18n auto-generate rule to detect and fix mismatched i18n IDs when keys are copied between modules.

📋 Problem

When developers copy translation keys between i18n files, they often forget to update the IDs, leading to incorrect namespace prefixes or key names:                                                                                                                       

```
// src/ui/modules/issue/i18n.ts                                                                                                                                               
field_description: {                                                                                                                                                          
   ru: 'Описание',                                                                                                                                                           
   en: 'Description',                                                                                                                                                        
   meta: {                                                                                                                                                                   
       id: 'agent.field_description:9ntzU',  // ❌  Wrong namespace - should be 'issue'                                                                                       
   },                                                                                                                                                                        
}                                                                                                                                                                             
```       
                                                                                                                                                                    
This causes:                                                                                                                                                                  
- Namespace mismatches: IDs from one module (e.g., agent) used in another (e.g., issue)                                                                                       
- Key mismatches: ID key doesn't match translation key (e.g., field_title vs field_description)                                                                               
- Translation system issues: Incorrect IDs break translation mapping
     
 ✨  Solution

Extended the auto-generate-translation-message-id ESLint rule with: 
1. ID Format Parsing: Parse existing IDs into namespace, key, and uuid components                                                                                             
2. Validation: Check that namespace matches file path and key matches translation key                                                                                         
3. Auto-fix: Replace incorrect IDs with properly formatted ones (new UUIDs)                                                                                                   
4. Opt-in: Controlled via validateId option (default: false for backward compatibility) 
